### PR TITLE
Update default admin username in setup-server.md

### DIFF
--- a/docs/admin_guide_docassemble/setup-server.md
+++ b/docs/admin_guide_docassemble/setup-server.md
@@ -379,7 +379,7 @@ Compose file to ensure you are setting the same flags in the new container.
 
 In a few minutes, your docassemble server will be up and running. Visit the website at the DNS
 name you chose, `https://apps.example.com`. Log in with the default username and password,
-admin@admin.com/password. Change it to something more secure.
+admin@example.com/password. Change it to something more secure.
 
 ### Monitor progress
 


### PR DESCRIPTION
Per [the docassemble instructions](https://docassemble.org/docs/docker.html#starting), the default username on installation in the `jhpyle/docassemble` image is `admin@example.com` not `admin@admin.com`.